### PR TITLE
Fix CVE-2023-49316

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "metapackage",
     "require": {
         "knplabs/gaufrette": "~0.3",
-        "phpseclib/phpseclib": "^2.0"
+        "phpseclib/phpseclib": "^2.0|^3.0.34"
     },
     "authors": [
         {


### PR DESCRIPTION
There is CVE-2023-49316 in package phpseclib/phpseclib < 3.0.34

The package version is 2 and in v3 they changed namespace. So I updated namespace and created a new Adapter for phpseclib v3 https://github.com/KnpLabs/Gaufrette/pull/711