### PR TITLE
Define MIT license at `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "gaufrette/phpseclib-sftp-adapter",
     "description": "PhpseclibSftp adapter for Gaufrette",
     "type": "metapackage",
+    "license": "MIT",
     "require": {
         "knplabs/gaufrette": "~0.3",
         "phpseclib/phpseclib": "^2.0"


### PR DESCRIPTION
Currently, the package definition does not include the [license](knplabs/gaufrette) type.
Since this is a open source package, the license declaration is important to expose how this package can be consumed.

I used the [MIT license](https://spdx.org/licenses/MIT.html) because this is already used at [knplabs/gaufrette](https://github.com/KnpLabs/Gaufrette/blob/ceb9f239f9c22f452bc09814cc4ad0700b26078e/composer.json#L7C5-L7C27).

By instance, I'm using a license checker to confirm that all my dependencies (direct or transitive) comply with my licensing constraints, but the absence of the license declaration in this package blocks its installation.

Please. let me know if you require further context or a different license type, like [Unlicense](https://spdx.org/licenses/Unlicense.html).

BTW, as the same situation seem the same in majority of packages under the `gaufrette/` vendor, I'd be glad to provide PRs for the remaining packages if this proposal is accepted.